### PR TITLE
Handle app receipt expirations properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+xcuserdata
+*.xcworkspace


### PR DESCRIPTION
In my own testing based on this code, I noticed that the Expiration Date field in the app receipt was not being handled at all. This is required if you want to check whether the app receipt has expired (mostly in the context of a Volume Purchase Program).

This pull request fixes this and cleans up a few more things :
- Parses the date strings and turns them to `NSDate` objects that are easier to access in code.
- Ignores empty fields.
- The verification function now looks for the presence of an expiration date in the past.
