### PR TITLE
Suppressed Clang Static Analyzer hit

### DIFF
--- a/VerifyStoreReceipt/VerifyStoreReceipt.m
+++ b/VerifyStoreReceipt/VerifyStoreReceipt.m
@@ -150,9 +150,10 @@ NSArray *parseInAppPurchasesData(NSData *inappData) {
 			// Attribute version
 			ASN1_get_object(&p, &length, &type, &xclass, seq_end - p);
 			if (type == V_ASN1_INTEGER && length == 1) {
-                // clang analyser hit (wontfix at the moment, since the code might come in handy later)
-                // But if someone has a convincing case throwing that out, I might do so, Roddi
-				attr_version = p[0];
+                		// Suppressed Clang Static Analyzer hit (stored value might come in handy later)
+				#ifndef __clang_analyzer__
+                    			attr_version = p[0];
+                		#endif
 			}
 			p += length;
             


### PR DESCRIPTION
Suppressed Clang Static Analyzer hit for unread attr_version variable (might be handy in future versions).
